### PR TITLE
Fix - Xcode 8 Beta 3 Fixes

### DIFF
--- a/Elevate.xcodeproj/project.pbxproj
+++ b/Elevate.xcodeproj/project.pbxproj
@@ -869,6 +869,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -912,6 +913,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -939,7 +941,6 @@
 				PRODUCT_NAME = Elevate;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -962,7 +963,6 @@
 				PRODUCT_NAME = Elevate;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -975,7 +975,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nike.ElevateTests;
 				PRODUCT_NAME = ElevateTests;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -989,7 +988,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.nike.ElevateTests;
 				PRODUCT_NAME = ElevateTests;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Elevate is a JSON parsing framework that leverages Swift to make parsing simple,
 ## Requirements
 
 - iOS 8.0+ / Mac OS X 10.10+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 8.0 beta 2+
+- Xcode 8.0 beta 3+
 
 ## Communication
 

--- a/Source/Decoder.swift
+++ b/Source/Decoder.swift
@@ -65,10 +65,7 @@ public class StringToIntDecoder: Decoder {
         - returns: The decoded `Int`.
     */
     public func decode(object: AnyObject) throws -> Any {
-        if let
-            intString = object as? String,
-            intValue = Int(intString)
-        {
+        if let intString = object as? String, let intValue = Int(intString) {
             return intValue
         }
 


### PR DESCRIPTION
This PR fixes up a compiler warning due to multiple optional binds now requiring multiple lets. It also fixes an issue in the project settings around the Swift version where it wasn't set on the project level which was causing issues with the OS X framework target.