### PR TITLE
Switching from AnyObject to Any

### DIFF
--- a/Source/Decodable.swift
+++ b/Source/Decodable.swift
@@ -38,7 +38,7 @@ public protocol Decodable {
 
         - throws: A ParserError.Validation or ParserError.Deserialization if decoding fails.
     */
-    init(json: AnyObject) throws
+    init(json: Any) throws
 }
 
 // MARK: - Primative Decodables
@@ -56,7 +56,7 @@ extension String: Decodable {
 
         - throws: A ParserError.Validation error if decoding fails.
     */
-    public init(json: AnyObject) throws {
+    public init(json: Any) throws {
         guard Parser.valueIsSpecifiedType(value: json, type: .string) else {
             throw ParserError.validation(failureReason: "JSON object was not of type: String")
         }
@@ -73,7 +73,7 @@ extension Int: Decodable {
 
         - throws: A ParserError.Validation error if decoding fails.
     */
-    public init(json: AnyObject) throws {
+    public init(json: Any) throws {
         guard Parser.valueIsSpecifiedType(value: json, type: .int) else {
             throw ParserError.validation(failureReason: "JSON object was not of type: Int")
         }
@@ -90,7 +90,7 @@ extension UInt: Decodable {
 
         - throws: A ParserError.Validation error if decoding fails.
     */
-    public init(json: AnyObject) throws {
+    public init(json: Any) throws {
         guard Parser.valueIsSpecifiedType(value: json, type: .uInt) else {
             throw ParserError.validation(failureReason: "JSON object was not of type: UInt")
         }
@@ -107,7 +107,7 @@ extension Float: Decodable {
 
         - throws: A ParserError.Validation error if decoding fails.
     */
-    public init(json: AnyObject) throws {
+    public init(json: Any) throws {
         guard Parser.valueIsSpecifiedType(value: json, type: .float) else {
             throw ParserError.validation(failureReason: "JSON object was not of type: Float")
         }
@@ -124,7 +124,7 @@ extension Double: Decodable {
 
         - throws: A ParserError.Validation error if decoding fails.
     */
-    public init(json: AnyObject) throws {
+    public init(json: Any) throws {
         guard Parser.valueIsSpecifiedType(value: json, type: .double) else {
             throw ParserError.validation(failureReason: "JSON object was not of type: Double")
         }
@@ -141,7 +141,7 @@ extension Bool: Decodable {
 
         - throws: A ParserError.Validation error if decoding fails.
     */
-    public init(json: AnyObject) throws {
+    public init(json: Any) throws {
         guard Parser.valueIsSpecifiedType(value: json, type: .bool) else {
             throw ParserError.validation(failureReason: "JSON object was not of type: Bool")
         }

--- a/Source/Decoder.swift
+++ b/Source/Decoder.swift
@@ -39,7 +39,7 @@ public protocol Decoder {
         - throws:  A ParserError.Validation error if object decoding fails.
         - returns: The parsed object.
     */
-    func decode(object: AnyObject) throws -> Any
+    func decode(object: Any) throws -> Any
 }
 
 // MARK: - Supplied Decoders
@@ -64,7 +64,7 @@ public class StringToIntDecoder: Decoder {
         - throws:  A ParserError.Validation error if int decoding fails.
         - returns: The decoded `Int`.
     */
-    public func decode(object: AnyObject) throws -> Any {
+    public func decode(object: Any) throws -> Any {
         if let intString = object as? String, let intValue = Int(intString) {
             return intValue
         }
@@ -111,7 +111,7 @@ public class DateDecoder: Decoder {
         - throws: ParserError.Validation
         - returns: The parsed date.
     */
-    public func decode(object: AnyObject) throws -> Any {
+    public func decode(object: Any) throws -> Any {
         guard let string = object as? String else {
             let description = "DateParser object to parse was not a String."
             throw ParserError.validation(failureReason: description)

--- a/Source/Parser.swift
+++ b/Source/Parser.swift
@@ -137,11 +137,9 @@ public class Parser {
     */
     public class func parseProperties(data: Data, closure: (ParserPropertyMaker) -> Void) throws -> [String: Any] {
         let result: [String: Any]
-        
-        do {
-            let options = JSONSerialization.ReadingOptions(rawValue: 0)
-            let json = try JSONSerialization.jsonObject(with: data, options: options)
 
+        do {
+            let json = try JSONSerialization.jsonObject(with: data, options: [])
             result = try parseProperties(json: json, closure: closure)
         } catch {
             if error is ParserError {

--- a/Source/Parser.swift
+++ b/Source/Parser.swift
@@ -181,16 +181,16 @@ public class Parser {
         - returns: The result Dictionary.
     */
     public class func parseProperties(json: Any, closure: (ParserPropertyMaker) -> Void) throws -> [String: Any] {
-        if let json = json as? [String: AnyObject] {
+        if let json = json as? [String: Any] {
             return try parsePropertiesForJSONDictionary(json, closure: closure)
-        } else if let json = json as? [AnyObject] {
+        } else if let json = json as? [Any] {
             return try parsePropertiesForJSONArray(json, closure: closure)
         } else {
             throw ParserError.validation(failureReason: "JSON object was not of type: [String: AnyObject] or [AnyObject]")
         }
     }
 
-    private class func parsePropertiesForJSONDictionary(_ dictionary: [String: AnyObject], closure: (ParserPropertyMaker) -> Void) throws -> [String: Any] {
+    private class func parsePropertiesForJSONDictionary(_ dictionary: [String: Any], closure: (ParserPropertyMaker) -> Void) throws -> [String: Any] {
         var parsingErrorDescriptions = [String]()
         var parsed = [String: Any]()
         let propertyMaker = ParserPropertyMaker()
@@ -198,8 +198,8 @@ public class Parser {
         closure(propertyMaker)
 
         for property in propertyMaker.properties {
-            let jsonValue: AnyObject = Parser.json(dictionary, forKeyPath: property.keyPath)
-            var parsedValue: AnyObject?
+            let jsonValue: Any = Parser.json(dictionary, forKeyPath: property.keyPath)
+            var parsedValue: Any?
 
             if property.optional && jsonValue is NSNull {
                 parsedValue = Optional.none
@@ -211,19 +211,19 @@ public class Parser {
                     parsedValue = jsonValue
                     parsed[property.keyPath] = jsonValue
                 case .uInt:
-                    parsedValue = (jsonValue as! NSNumber).uintValue as AnyObject
+                    parsedValue = (jsonValue as! NSNumber).uintValue
                     parsed[property.keyPath] = parsedValue
                 case .int:
-                    parsedValue = (jsonValue as! NSNumber).intValue as AnyObject
+                    parsedValue = (jsonValue as! NSNumber).intValue
                     parsed[property.keyPath] = parsedValue
                 case .float:
-                    parsedValue = (jsonValue as! NSNumber).floatValue as AnyObject
+                    parsedValue = (jsonValue as! NSNumber).floatValue
                     parsed[property.keyPath] = parsedValue
                 case .double:
-                    parsedValue = (jsonValue as! NSNumber).doubleValue as AnyObject
+                    parsedValue = (jsonValue as! NSNumber).doubleValue
                     parsed[property.keyPath] = parsedValue
                 case .bool:
-                    parsedValue = (jsonValue as! NSNumber).boolValue as AnyObject
+                    parsedValue = (jsonValue as! NSNumber).boolValue
                     parsed[property.keyPath] = parsedValue
                 case .array:
                     if let decodingMethod = property.decodingMethod {
@@ -251,7 +251,7 @@ public class Parser {
                 }
 
                 if let decodingMethod = property.decodingMethod {
-                    if let value: AnyObject = parsedValue {
+                    if let value: Any = parsedValue {
                         do {
                             let result: Any
 
@@ -279,7 +279,7 @@ public class Parser {
         return parsed
     }
 
-    private class func parsePropertiesForJSONArray(_ array: [AnyObject], closure: (ParserPropertyMaker) -> Void) throws -> [String: Any] {
+    private class func parsePropertiesForJSONArray(_ array: [Any], closure: (ParserPropertyMaker) -> Void) throws -> [String: Any] {
         var parsed = [String: Any]()
         let propertyMaker = ParserPropertyMaker()
 
@@ -304,7 +304,7 @@ public class Parser {
 
     // MARK: Internal - Validation Methods
 
-    class func valueIsSpecifiedType(value: AnyObject, type: ParserPropertyType) -> Bool {
+    class func valueIsSpecifiedType(value: Any, type: ParserPropertyType) -> Bool {
         var isValid = false
 
         switch value {
@@ -321,9 +321,9 @@ public class Parser {
             }
         case is NSString:
             isValid = type == .string || type == .url
-        case is [AnyObject]:
+        case is [Any]:
             isValid = type == .array
-        case is [String: AnyObject]:
+        case is [String: Any]:
             isValid = type == .dictionary
         default:
             break
@@ -334,8 +334,8 @@ public class Parser {
 
     // MARK: Private - Parser Helper Methods
 
-    private class func json(_ dictionary: [String: AnyObject], forKeyPath keypath: String) -> AnyObject {
-        var json: AnyObject? = dictionary as AnyObject
+    private class func json(_ dictionary: [String: Any], forKeyPath keypath: String) -> Any {
+        var json: Any? = dictionary
 
         if dictionary.keys.contains(keypath) {
             json = dictionary[keypath]
@@ -343,7 +343,7 @@ public class Parser {
             let keys = keypath.characters.split() { $0 == "." }.map { String($0) }
 
             for key in keys {
-                if let dictionary = json as? [String: AnyObject], let value: AnyObject = dictionary[key] {
+                if let dictionary = json as? [String: Any], let value = dictionary[key] {
                     json = value
                 } else {
                     json = nil
@@ -355,12 +355,13 @@ public class Parser {
         return json ?? NSNull()
     }
 
-    private class func validateValue(_ value: AnyObject, forProperty property: ParserProperty) -> String?  {
-        var errorDescription: String? = nil
+    private class func validateValue(_ value: Any, forProperty property: ParserProperty) -> String?  {
+        let isNull = value is NSNull
+        var errorDescription: String?
 
-        if property.optional == false && value is NSNull {
+        if property.optional == false && isNull {
             errorDescription = "Required key path [\(property.keyPath)] was missing or null"
-        } else if property.optional == true && value is NSNull {
+        } else if property.optional == true && isNull {
             return nil
         } else {
             if !valueIsSpecifiedType(value: value, type: property.type) {
@@ -371,11 +372,11 @@ public class Parser {
         return errorDescription
     }
 
-    private class func parseArray(data: AnyObject, decodingMethod: ParserProperty.DecodingMethod) throws -> [Any] {
+    private class func parseArray(data: Any, decodingMethod: ParserProperty.DecodingMethod) throws -> [Any] {
         var parsed = [Any]()
         var parsingErrorDescriptions = [String]()
 
-        if let items = data as? [AnyObject] {
+        if let items = data as? [Any] {
             for (index, item) in items.enumerated() {
                 do {
                     let result: Any

--- a/Source/PropertyExtraction.swift
+++ b/Source/PropertyExtraction.swift
@@ -68,8 +68,7 @@ public func <-? <T>(lhs: [String: Any], rhs: String) -> T? {
     - returns: Array for the key in the dictionary.
 */
 public func <--! <T>(lhs: [String: Any], rhs: String) -> [T] {
-    guard let array = lhs[rhs] else { return [] }
-    return (array as! [Any]).map { $0 as! T }
+    return lhs[rhs] as! [T]
 }
 
 /**
@@ -81,6 +80,6 @@ public func <--! <T>(lhs: [String: Any], rhs: String) -> [T] {
     - returns: Array for the key in the dictionary.
 */
 public func <--? <T>(lhs: [String: Any], rhs: String) -> [T]? {
-    guard let array = lhs[rhs] else { return nil }
-    return (array as? [Any])?.map { $0 as! T }
+    guard let array = lhs[rhs] as? [T] else { return nil }
+    return array
 }

--- a/Tests/DecoderTests.swift
+++ b/Tests/DecoderTests.swift
@@ -33,7 +33,7 @@ class ValidDecoder: Decoder {
         self.toDictionary = toDictionary
     }
 
-    func decode(object: AnyObject) throws -> Any {
+    func decode(object: Any) throws -> Any {
         let result = try Parser.parseProperties(json: object) { make in
             make.propertyForKeyPath("subUInt", type: .uInt)
             make.propertyForKeyPath("subInt", type: .int)
@@ -53,7 +53,7 @@ class ValidDecoder: Decoder {
 }
 
 class InvalidDecoder: Decoder {
-    func decode(object: AnyObject) throws -> Any {
+    func decode(object: Any) throws -> Any {
         return try Parser.parseProperties(json: object) { make in
             make.propertyForKeyPath("subUInt", type: .string)
             make.propertyForKeyPath("missingSubInt", type: .int)

--- a/Tests/Decoders.swift
+++ b/Tests/Decoders.swift
@@ -26,7 +26,7 @@ import Elevate
 import Foundation
 
 struct TestObjectDecoder: Decoder {
-    func decode(object: AnyObject) throws -> Any {
+    func decode(object: Any) throws -> Any {
         struct KeyPath {
             static let subUInt = "subUInt"
             static let subInt = "subInt"

--- a/Tests/ModelObjects.swift
+++ b/Tests/ModelObjects.swift
@@ -40,7 +40,7 @@ struct TestObject {
 // MARK: -
 
 extension TestObject: Decodable {
-    init(json: AnyObject) throws {
+    init(json: Any) throws {
         let subUIntKeyPath = "subUInt"
         let subIntKeyPath = "subInt"
         let subStringKeyPath = "subString"
@@ -66,7 +66,7 @@ struct InvalidDecodable {
 // MARK: -
 
 extension InvalidDecodable: Decodable {
-    init(json: AnyObject) throws {
+    init(json: Any) throws {
         let invalidKeyPath = "invalid"
 
         let properties = try Parser.parseProperties(json: json) { make in

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -47,7 +47,7 @@ class PerformanceTestCase: BaseTestCase {
 private class PerformanceDecodable: Decodable {
     static let dateDecoder = DateDecoder(dateFormatString: BaseTestCase.DateFormats.Format1)
 
-    required init(json: AnyObject) throws {
+    required init(json: Any) throws {
         let _ = try Parser.parseProperties(json: json) { make in
             make.propertyForKeyPath("testUInt", type: ParserPropertyType.uInt)
             make.propertyForKeyPath("testInt", type: .int)

--- a/Tests/PerformanceTests.swift
+++ b/Tests/PerformanceTests.swift
@@ -30,14 +30,8 @@ class PerformanceTestCase: BaseTestCase {
     func testThatItParsesValuesForAllPropertyTypesInSufficientTime() {
         // Given
         let data = loadJSONDataForFileNamed("PropertyTypesTest")
-        let json = try! JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
-        let dataArray: [AnyObject] = {
-            var array: [AnyObject] = []
-            for _ in 0...1000 {
-                array.append(json as AnyObject)
-            }
-            return array
-        }()
+        let json = try! JSONSerialization.jsonObject(with: data, options: .allowFragments)
+        let dataArray: [Any] = (0...1000).map { _ in json }
 
         self.measure {
             // When


### PR DESCRIPTION
This PR has a few commits cleaning up some of the older logic to use some more condensed logic as well as a big change which switches from `AnyObject` to `Any`throughout the Elevate APIs. Since `JSONSerialization` has now moved to using `Any` instead of `AnyObject`, our Elevate APIs should match. We also may "have" to do this to support `Linux`.

> We still need to confirm this.

These changes have a small performance impact that needs to be called out. I've noticed the performance test increase by about 7-8% when running several iterations in the simulator. It may be possible to figure out which cast is being more costly. I'm assuming we're now having to bridge back and forth between Objective-C objects and Swift objects than we were before with AnyObject. However, this may not matter in the end if `Linux` can only use `Any`.

> We're thinking Linux may be the main reason this change is necessary since it won't have bridging between Objective-C and Swift which is why `AnyObject` works. All values supported by `JSONSerialization` in the OSS version of Swift are value types.