### PR TITLE
Feature - Dictionary Decodable Conformance

### DIFF
--- a/Source/Decodable.swift
+++ b/Source/Decodable.swift
@@ -66,7 +66,7 @@ extension Int: Decodable {
             throw ParserError.validation(failureReason: "JSON object was not of type: Int")
         }
 
-        self = (json as! NSNumber).intValue
+        self = json as! Int
     }
 }
 
@@ -81,7 +81,7 @@ extension UInt: Decodable {
             throw ParserError.validation(failureReason: "JSON object was not of type: UInt")
         }
 
-        self = (json as! NSNumber).uintValue
+        self = json as! UInt
     }
 }
 
@@ -96,7 +96,7 @@ extension Float: Decodable {
             throw ParserError.validation(failureReason: "JSON object was not of type: Float")
         }
 
-        self = (json as! NSNumber).floatValue
+        self = json as! Float
     }
 }
 
@@ -111,7 +111,7 @@ extension Double: Decodable {
             throw ParserError.validation(failureReason: "JSON object was not of type: Double")
         }
 
-        self = (json as! NSNumber).doubleValue
+        self = json as! Double
     }
 }
 
@@ -126,7 +126,6 @@ extension Bool: Decodable {
             throw ParserError.validation(failureReason: "JSON object was not of type: Bool")
         }
 
-        self = (json as! NSNumber).boolValue
     }
 }
 
@@ -139,6 +138,7 @@ extension Array: Decodable {
         }
 
         self = json as! [Element]
+        self = json as! Bool
     }
 }
 

--- a/Source/Decodable.swift
+++ b/Source/Decodable.swift
@@ -129,3 +129,25 @@ extension Bool: Decodable {
         self = (json as! NSNumber).boolValue
     }
 }
+
+// MARK: - Collection Decodables
+
+extension Array: Decodable {
+    public init(json: Any) throws {
+        guard json is [Element] else {
+            throw ParserError.validation(failureReason: "JSON object was not of type: \(Element.self)")
+        }
+
+        self = json as! [Element]
+    }
+}
+
+extension Dictionary: Decodable {
+    public init(json: Any) throws {
+        guard json is [Key: Value] else {
+            throw ParserError.validation(failureReason: "JSON object was not of type: [\(Key.self), \(Value.self)]")
+        }
+
+        self = json as! [Key: Value]
+    }
+}

--- a/Source/Decodable.swift
+++ b/Source/Decodable.swift
@@ -126,18 +126,6 @@ extension Bool: Decodable {
             throw ParserError.validation(failureReason: "JSON object was not of type: Bool")
         }
 
-    }
-}
-
-// MARK: - Collection Decodables
-
-extension Array: Decodable {
-    public init(json: Any) throws {
-        guard json is [Element] else {
-            throw ParserError.validation(failureReason: "JSON object was not of type: \(Element.self)")
-        }
-
-        self = json as! [Element]
         self = json as! Bool
     }
 }
@@ -145,7 +133,7 @@ extension Array: Decodable {
 extension Dictionary: Decodable {
     public init(json: Any) throws {
         guard json is [Key: Value] else {
-            throw ParserError.validation(failureReason: "JSON object was not of type: [\(Key.self), \(Value.self)]")
+            throw ParserError.validation(failureReason: "JSON object was not of type: \(Dictionary<Key, Value>.self)")
         }
 
         self = json as! [Key: Value]

--- a/Source/Decodable.swift
+++ b/Source/Decodable.swift
@@ -36,9 +36,9 @@ public protocol Decodable {
     init(json: Any) throws
 }
 
-// MARK: - Primative Decodables
+// MARK: - Primitive Decodables
 
-/// The primative decodables implemented below are used by the parser when parsing an array of primative values. The
+/// The primitive decodables implemented below are used by the parser when parsing an array of primitive values. The
 /// input is expected to be of the same type as the object and will be validated and cast as such.
 extension String: Decodable {
     /// Implements the `Decodable` protocol for the `String` type. Expects input to be a `String`.

--- a/Source/Encodable.swift
+++ b/Source/Encodable.swift
@@ -30,16 +30,16 @@ public protocol Encodable {
     var json: Any { get }
 }
 
-protocol JSONPrimative: Encodable {}
+protocol JSONPrimitive: Encodable {}
 
-extension JSONPrimative {
+extension JSONPrimitive {
     /// Returns `self` as type `Any`.
     public var json: Any { return self }
 }
 
 // MARK: - String
 
-extension String: JSONPrimative { }
+extension String: JSONPrimitive { }
 
 extension URL: Encodable {
     /// Returns the `absoluteString` of `self` as type `Any`.
@@ -48,25 +48,25 @@ extension URL: Encodable {
 
 // MARK: - Int
 
-extension Int: JSONPrimative {}
-extension Int8: JSONPrimative {}
-extension Int16: JSONPrimative {}
-extension Int32: JSONPrimative {}
-extension Int64: JSONPrimative {}
+extension Int: JSONPrimitive {}
+extension Int8: JSONPrimitive {}
+extension Int16: JSONPrimitive {}
+extension Int32: JSONPrimitive {}
+extension Int64: JSONPrimitive {}
 
 // MARK: - UInt
 
-extension UInt: JSONPrimative {}
-extension UInt8: JSONPrimative {}
-extension UInt16: JSONPrimative {}
-extension UInt32: JSONPrimative {}
-extension UInt64: JSONPrimative {}
+extension UInt: JSONPrimitive {}
+extension UInt8: JSONPrimitive {}
+extension UInt16: JSONPrimitive {}
+extension UInt32: JSONPrimitive {}
+extension UInt64: JSONPrimitive {}
 
 // MARK: - Number
 
-extension Float: JSONPrimative {}
-extension Double: JSONPrimative {}
-extension Bool: JSONPrimative {}
+extension Float: JSONPrimitive {}
+extension Double: JSONPrimitive {}
+extension Bool: JSONPrimitive {}
 
 // MARK: - Collection
 

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -30,12 +30,12 @@ class DecodableTestCase: BaseTestCase {
 
     // MARK: - Decodable API Success Tests
 
-        // Given
-        let data = loadJSONDataForFileNamed("PropertyTypesTest")
-
-        // When
     func testThatDecodeOnADecodableSucceeds() {
         do {
+            // Given
+            let data = loadJSONDataForFileNamed("PropertyTypesTest")
+
+            // When
             let testObject: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "sub-object")
 
             // Then
@@ -47,12 +47,12 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-        // Given
-        let data = loadJSONDataForFileNamed("ArrayTest")
-
-        // When
     func testThatDecodeOnAnArraySucceeds() {
         do {
+            // Given
+            let data = loadJSONDataForFileNamed("ArrayTest")
+
+            // When
             let result: [TestObject] = try Elevate.decodeArray(from: data, atKeyPath: "items")
 
             // Then
@@ -67,12 +67,12 @@ class DecodableTestCase: BaseTestCase {
     // MARK: - Decodable Primitive Success Tests
 
     func testThatParseObjectParsesStringSuccessfully() {
-        // Given
-        let data = "{ \"key\":\"981a383074461fcbf7b9c67e2cb7bd13502d664cad0b254b8f426cd77c62d83e\" }"
-            .data(using: String.Encoding.utf8)!
-
-        // When
         do {
+            // Given
+            let data = "{ \"key\":\"981a383074461fcbf7b9c67e2cb7bd13502d664cad0b254b8f426cd77c62d83e\" }"
+                .data(using: String.Encoding.utf8)!
+
+            // When
             let result: String = try Elevate.decodeObject(from: data, atKeyPath: "key")
 
             // Then
@@ -83,11 +83,11 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectParsesIntSuccessfully() {
-        // Given
-        let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
-
-        // When
         do {
+            // Given
+            let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
+
+            // When
             let result: Int = try Elevate.decodeObject(from: data, atKeyPath: "key")
 
             // Then
@@ -98,11 +98,11 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectParsesUIntSuccessfully() {
-        // Given
-        let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
-
-        // When
         do {
+            // Given
+            let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
+
+            // When
             let result: UInt = try Elevate.decodeObject(from: data, atKeyPath: "key")
 
             // Then
@@ -113,11 +113,11 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectParsesFloatSuccessfully() {
-        // Given
-        let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
-
-        // When
         do {
+            // Given
+            let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
+
+            // When
             let result: Float = try Elevate.decodeObject(from: data, atKeyPath: "key")
 
             // Then
@@ -128,11 +128,11 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectParsesDoubleSuccessfully() {
-        // Given
-        let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
-
-        // When
         do {
+            // Given
+            let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
+
+            // When
             let result: Double = try Elevate.decodeObject(from: data, atKeyPath: "key")
 
             // Then
@@ -143,11 +143,11 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectParsesBoolSuccessfully() {
-        // Given
-        let data = "{ \"key\" : true }".data(using: String.Encoding.utf8)!
-
-        // When
         do {
+            // Given
+            let data = "{ \"key\" : true }".data(using: String.Encoding.utf8)!
+
+            // When
             let result: Bool = try Elevate.decodeObject(from: data, atKeyPath: "key")
 
             // Then
@@ -160,15 +160,16 @@ class DecodableTestCase: BaseTestCase {
     // MARK: - Decodable Primitive Failure Tests
 
     func testThatParseObjectThrowsForInvalidString() {
-        // Given
-        let json = ["key": 0] as Any
-
-        // When
         do {
+            // Given
+            let json = ["key": 0] as Any
+
+            // When
             let _ = try String(json: json)
 
             XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
+            // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: String")
         } catch {
             XCTFail("Incorrect error type was thrown while parsing Decoable")
@@ -176,15 +177,16 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectThrowsForInvalidInt() {
-        // Given
-        let json = ["key": "invalid"] as Any
-
-        // When
         do {
+            // Given
+            let json = ["key": "invalid"] as Any
+
+            // When
             let _ = try Int(json: json)
 
             XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
+            // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Int")
         } catch {
             XCTFail("Incorrect error type was thrown while parsing Decoable")
@@ -192,15 +194,16 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectThrowsForInvalidUInt() {
-        // Given
-        let json = ["key": "invaild"] as Any
-
-        // When
         do {
+            // Given
+            let json = ["key": "invaild"] as Any
+
+            // When
             let _ = try UInt(json: json)
 
             XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
+            // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: UInt")
         } catch {
             XCTFail("Incorrect error type was thrown while parsing Decoable")
@@ -208,15 +211,16 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectThrowsForInvalidFloat() {
-        // Given
-        let json = ["key": "invalid"] as Any
-
-        // When
         do {
+            // Given
+            let json = ["key": "invalid"] as Any
+
+            // When
             let _ = try Float(json: json)
 
             XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
+            // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Float")
         } catch {
             XCTFail("Incorrect error type was thrown while parsing Decoable")
@@ -224,15 +228,16 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectThrowsForInvalidDouble() {
-        // Given
-        let json = ["key": "invalid"] as Any
-
-        // When
         do {
+            // Given
+            let json = ["key": "invalid"] as Any
+
+            // When
             let _ = try Double(json: json)
 
             XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
+            // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Double")
         } catch {
             XCTFail("Incorrect error type was thrown while parsing Decoable")
@@ -240,15 +245,16 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseObjectThrowsForInvalidBool() {
-        // Given
-        let json = ["key": 0] as Any
-
-        // When
         do {
+            // Given
+            let json = ["key": 0] as Any
+
+            // When
             let _ = try Bool(json: json)
 
             XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
+            // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Bool")
         } catch {
             XCTFail("Incorrect error type was thrown while parsing Decoable")
@@ -258,11 +264,11 @@ class DecodableTestCase: BaseTestCase {
     // MARK: - Decodable Failure Tests
 
     func testThatParseThrowsWithInvalidJSON() {
-        // Given
-        let data = "some random data that isn't json".data(using: String.Encoding.utf8)!
-
-        // When
         do {
+            // Given
+            let data = "some random data that isn't json".data(using: String.Encoding.utf8)!
+
+            // When
             let _: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "sub-object")
 
             XCTFail("Parser unexpectedly succeeded.")
@@ -280,11 +286,11 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseThrowsWithMissingKeyPath() {
-        // Given
-        let data = loadJSONDataForFileNamed("PropertyTypesTest")
-
-        // When
         do {
+            // Given
+            let data = loadJSONDataForFileNamed("PropertyTypesTest")
+
+            // When
             let _: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "key_does_not_exist")
 
             XCTFail("Parser unexpectedly succeeded.")
@@ -299,11 +305,11 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatParseThrowsWhenDecodableThrows() {
-        // Given
-        let data = loadJSONDataForFileNamed("PropertyTypesTest")
-
-        // When
         do {
+            // Given
+            let data = loadJSONDataForFileNamed("PropertyTypesTest")
+
+            // When
             let _: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "testDictionary")
 
             XCTFail("Parser unexpectedly succeeded.")
@@ -323,17 +329,18 @@ class DecodableTestCase: BaseTestCase {
     }
 
     func testThatItThrowsWithInvalidDecodable() {
-        // Given
-        let data = loadJSONDataForFileNamed("ArrayTest")
-
-        // When
         do {
+            // Given
+            let data = loadJSONDataForFileNamed("ArrayTest")
+
+            // When
             _ = try Parser.parseEntity(data: data) { schema in
                 schema.addProperty(keyPath: "items", type: .array, decodableType: InvalidDecodable.self)
             }
 
             XCTFail("Parser unexpectedly succeeded")
         } catch let error as ParserError {
+            // Then
             let actualValue = error.description
             let expectedValue = "Parser Validation Error - Error parsing array object at index 0 with parser [InvalidDecodable]"
             XCTAssertTrue(actualValue.hasPrefix(expectedValue), "Error message for Array Decodable did not match expected value")
@@ -342,25 +349,25 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-// As of Xcode 7.3 there is a compiler bug in Release configuration when executing type.init below
-#if DEBUG
     func testThatItThrowsWithIncorrectInputType() {
-        decodableErrorTest(String.self, value: 1)
-        decodableErrorTest(Int.self, value: "1")
-        decodableErrorTest(UInt.self, value: "1")
-        decodableErrorTest(Float.self, value: "1")
-        decodableErrorTest(Double.self, value: "1")
-        decodableErrorTest(Bool.self, value: "1")
+        decodableErrorTest(type: String.self, value: 1)
+        decodableErrorTest(type: Int.self, value: "1")
+        decodableErrorTest(type: UInt.self, value: "1")
+        decodableErrorTest(type: Float.self, value: "1")
+        decodableErrorTest(type: Double.self, value: "1")
+        decodableErrorTest(type: Bool.self, value: "1")
     }
 
     // MARK: - Private - Helper Methods
 
     private func decodableErrorTest(type: Decodable.Type, value: Any) {
         do {
+            // Given, When
             let _ = try type.init(json: value)
 
             XCTFail("Parser unexpectedly succeeded")
         } catch let error as ParserError {
+            // Then
             let actualValue = error.failureReason
             let expectedValue = "JSON object was not of type: \(type)"
             XCTAssertEqual(actualValue, expectedValue, "Decodable error message did not match expected value.")
@@ -368,5 +375,4 @@ class DecodableTestCase: BaseTestCase {
             XCTFail("Parser error was of incorrect type.")
         }
     }
-#endif
 }

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -30,7 +30,7 @@ class DecodableTestCase: BaseTestCase {
 
     // MARK: - Decodable API Success Tests
 
-    func testThatDecodeOnADecodableSucceeds() {
+    func testThatDecodeObjectWithDecodableTypeSucceeds() {
         do {
             // Given
             let data = loadJSONDataForFileNamed("PropertyTypesTest")
@@ -47,7 +47,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatDecodeOnAnArraySucceeds() {
+    func testThatDecodeArrayWithDecodableArraySucceeds() {
         do {
             // Given
             let data = loadJSONDataForFileNamed("ArrayTest")
@@ -66,7 +66,7 @@ class DecodableTestCase: BaseTestCase {
 
     // MARK: - Decodable Primitive Success Tests
 
-    func testThatParseObjectParsesStringSuccessfully() {
+    func testThatDecodeObjectDecodesStringSuccessfully() {
         do {
             // Given
             let data = "{ \"key\":\"981a383074461fcbf7b9c67e2cb7bd13502d664cad0b254b8f426cd77c62d83e\" }"
@@ -82,7 +82,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectParsesIntSuccessfully() {
+    func testThatDecodeObjectDecodesIntSuccessfully() {
         do {
             // Given
             let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
@@ -97,7 +97,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectParsesUIntSuccessfully() {
+    func testThatDecodeObjectDecodesUIntSuccessfully() {
         do {
             // Given
             let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
@@ -112,7 +112,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectParsesFloatSuccessfully() {
+    func testThatDecodeObjectDecodesFloatSuccessfully() {
         do {
             // Given
             let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
@@ -127,7 +127,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectParsesDoubleSuccessfully() {
+    func testThatDecodeObjectDecodesDoubleSuccessfully() {
         do {
             // Given
             let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
@@ -142,7 +142,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectParsesBoolSuccessfully() {
+    func testThatDecodeObjectDecodesBoolSuccessfully() {
         do {
             // Given
             let data = "{ \"key\" : true }".data(using: String.Encoding.utf8)!
@@ -159,7 +159,7 @@ class DecodableTestCase: BaseTestCase {
 
     // MARK: - Decodable Primitive Failure Tests
 
-    func testThatParseObjectThrowsForInvalidString() {
+    func testThatStringDecodableInitializerThrowsForInvalidString() {
         do {
             // Given
             let json = ["key": 0] as Any
@@ -176,7 +176,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectThrowsForInvalidInt() {
+    func testThatIntDecodableInitializerThrowsForInvalidInt() {
         do {
             // Given
             let json = ["key": "invalid"] as Any
@@ -193,7 +193,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectThrowsForInvalidUInt() {
+    func testThatUIntDecodableInitializerThrowsForInvalidUInt() {
         do {
             // Given
             let json = ["key": "invaild"] as Any
@@ -210,7 +210,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectThrowsForInvalidFloat() {
+    func testThatFloatDecodableInitializerThrowsForInvalidFloat() {
         do {
             // Given
             let json = ["key": "invalid"] as Any
@@ -227,7 +227,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectThrowsForInvalidDouble() {
+    func testThatDoubleDecodableInitializerThrowsForInvalidDouble() {
         do {
             // Given
             let json = ["key": "invalid"] as Any
@@ -244,7 +244,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseObjectThrowsForInvalidBool() {
+    func testThatBoolDecodableInitializerThrowsForInvalidBool() {
         do {
             // Given
             let json = ["key": 0] as Any
@@ -263,7 +263,7 @@ class DecodableTestCase: BaseTestCase {
 
     // MARK: - Decodable Failure Tests
 
-    func testThatParseThrowsWithInvalidJSON() {
+    func testThatDecodeObjectThrowsWithInvalidJSON() {
         do {
             // Given
             let data = "some random data that isn't json".data(using: String.Encoding.utf8)!
@@ -285,7 +285,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseThrowsWithMissingKeyPath() {
+    func testThatDecodeObjectThrowsWithMissingKeyPath() {
         do {
             // Given
             let data = loadJSONDataForFileNamed("PropertyTypesTest")
@@ -304,7 +304,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseThrowsWhenDecodableThrows() {
+    func testThatDecodeObjectThrowsWhenDecodableThrows() {
         do {
             // Given
             let data = loadJSONDataForFileNamed("PropertyTypesTest")
@@ -328,7 +328,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatItThrowsWithInvalidDecodable() {
+    func testThatParserParseEntityThrowsWithInvalidDecodable() {
         do {
             // Given
             let data = loadJSONDataForFileNamed("ArrayTest")
@@ -349,7 +349,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatItThrowsWithIncorrectInputType() {
+    func testThatDecodableInitializerThrowsWithIncorrectInputType() {
         decodableErrorTest(type: String.self, value: 1)
         decodableErrorTest(type: Int.self, value: "1")
         decodableErrorTest(type: UInt.self, value: "1")

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -70,7 +70,7 @@ class DecodableTestCase: BaseTestCase {
         do {
             // Given
             let data = "{ \"key\":\"981a383074461fcbf7b9c67e2cb7bd13502d664cad0b254b8f426cd77c62d83e\" }"
-                .data(using: String.Encoding.utf8)!
+                .data(using: .utf8)!
 
             // When
             let result: String = try Elevate.decodeObject(from: data, atKeyPath: "key")
@@ -85,7 +85,7 @@ class DecodableTestCase: BaseTestCase {
     func testThatDecodeObjectDecodesIntSuccessfully() {
         do {
             // Given
-            let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
+            let data = "{ \"key\" : 7 }".data(using: .utf8)!
 
             // When
             let result: Int = try Elevate.decodeObject(from: data, atKeyPath: "key")
@@ -100,7 +100,7 @@ class DecodableTestCase: BaseTestCase {
     func testThatDecodeObjectDecodesUIntSuccessfully() {
         do {
             // Given
-            let data = "{ \"key\" : 7 }".data(using: String.Encoding.utf8)!
+            let data = "{ \"key\" : 7 }".data(using: .utf8)!
 
             // When
             let result: UInt = try Elevate.decodeObject(from: data, atKeyPath: "key")
@@ -115,7 +115,7 @@ class DecodableTestCase: BaseTestCase {
     func testThatDecodeObjectDecodesFloatSuccessfully() {
         do {
             // Given
-            let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
+            let data = "{ \"key\" : 7.1 }".data(using: .utf8)!
 
             // When
             let result: Float = try Elevate.decodeObject(from: data, atKeyPath: "key")
@@ -130,7 +130,7 @@ class DecodableTestCase: BaseTestCase {
     func testThatDecodeObjectDecodesDoubleSuccessfully() {
         do {
             // Given
-            let data = "{ \"key\" : 7.1 }".data(using: String.Encoding.utf8)!
+            let data = "{ \"key\" : 7.1 }".data(using: .utf8)!
 
             // When
             let result: Double = try Elevate.decodeObject(from: data, atKeyPath: "key")
@@ -145,7 +145,7 @@ class DecodableTestCase: BaseTestCase {
     func testThatDecodeObjectDecodesBoolSuccessfully() {
         do {
             // Given
-            let data = "{ \"key\" : true }".data(using: String.Encoding.utf8)!
+            let data = "{ \"key\" : true }".data(using: .utf8)!
 
             // When
             let result: Bool = try Elevate.decodeObject(from: data, atKeyPath: "key")
@@ -172,7 +172,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: String")
         } catch {
-            XCTFail("Incorrect error type was thrown while parsing Decoable")
+            XCTFail("Incorrect error type was thrown while parsing Decodable")
         }
     }
 
@@ -189,7 +189,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Int")
         } catch {
-            XCTFail("Incorrect error type was thrown while parsing Decoable")
+            XCTFail("Incorrect error type was thrown while parsing Decodable")
         }
     }
 
@@ -206,7 +206,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: UInt")
         } catch {
-            XCTFail("Incorrect error type was thrown while parsing Decoable")
+            XCTFail("Incorrect error type was thrown while parsing Decodable")
         }
     }
 
@@ -223,7 +223,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Float")
         } catch {
-            XCTFail("Incorrect error type was thrown while parsing Decoable")
+            XCTFail("Incorrect error type was thrown while parsing Decodable")
         }
     }
 
@@ -240,7 +240,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Double")
         } catch {
-            XCTFail("Incorrect error type was thrown while parsing Decoable")
+            XCTFail("Incorrect error type was thrown while parsing Decodable")
         }
     }
 
@@ -257,7 +257,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Bool")
         } catch {
-            XCTFail("Incorrect error type was thrown while parsing Decoable")
+            XCTFail("Incorrect error type was thrown while parsing Decodable")
         }
     }
 
@@ -266,7 +266,7 @@ class DecodableTestCase: BaseTestCase {
     func testThatDecodeObjectThrowsWithInvalidJSON() {
         do {
             // Given
-            let data = "some random data that isn't json".data(using: String.Encoding.utf8)!
+            let data = "some random data that isn't json".data(using: .utf8)!
 
             // When
             let _: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "sub-object")

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -64,7 +64,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    // MARK: - Decodable Primative Success Tests
+    // MARK: - Decodable Primitive Success Tests
 
     func testThatParseObjectParsesStringSuccessfully() {
         // Given
@@ -157,7 +157,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    // MARK: - Decoable Primative Failure Tests
+    // MARK: - Decoable Primitive Failure Tests
 
     func testThatParseObjectThrowsForInvalidString() {
         // Given

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -43,7 +43,7 @@ class DecodableTestCase: BaseTestCase {
             XCTAssertEqual(testObject.subInt, -1, "test object subInt does not match expected value")
             XCTAssertEqual(testObject.subString, "sub test string", "test object subString does not match expected value")
         } catch {
-            XCTFail("Parser unexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -60,7 +60,7 @@ class DecodableTestCase: BaseTestCase {
             XCTAssertEqual(result[1].subInt, 1, "array item 0 subInt does not match expected value")
             XCTAssertEqual(result[2].subInt, 2, "array item 0 subInt does not match expected value")
         } catch {
-            XCTFail("Parser uneexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -78,7 +78,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(result, "981a383074461fcbf7b9c67e2cb7bd13502d664cad0b254b8f426cd77c62d83e")
         } catch {
-            XCTFail("Parser unexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -93,7 +93,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(result, 7)
         } catch {
-            XCTFail("Parser unexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -108,7 +108,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(result, 7)
         } catch {
-            XCTFail("Parser unexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -123,7 +123,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(result, 7.1)
         } catch {
-            XCTFail("Parser unexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -138,7 +138,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertEqual(result, 7.1)
         } catch {
-            XCTFail("Parser unexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -153,7 +153,7 @@ class DecodableTestCase: BaseTestCase {
             // Then
             XCTAssertTrue(result)
         } catch {
-            XCTFail("Parser unexpectedly failed by throwing error: \(error)")
+            XCTFail("Test unexpectedly failed with error: \(error)")
         }
     }
 
@@ -167,7 +167,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _ = try String(json: json)
 
-            XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
+            XCTFail("String initializer unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: String")
@@ -184,7 +184,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _ = try Int(json: json)
 
-            XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
+            XCTFail("Int initializer unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Int")
@@ -201,7 +201,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _ = try UInt(json: json)
 
-            XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
+            XCTFail("UInt initializer unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: UInt")
@@ -218,7 +218,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _ = try Float(json: json)
 
-            XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
+            XCTFail("Float initializer unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Float")
@@ -235,7 +235,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _ = try Double(json: json)
 
-            XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
+            XCTFail("Double initializer unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Double")
@@ -252,7 +252,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _ = try Bool(json: json)
 
-            XCTFail("Parser unexpectedly succeeded in parsing data of incorrect type")
+            XCTFail("Bool initializer unexpectedly succeeded in parsing data of incorrect type")
         } catch let error as ParserError {
             // Then
             XCTAssertEqual(error.failureReason, "JSON object was not of type: Bool")
@@ -271,7 +271,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "sub-object")
 
-            XCTFail("Parser unexpectedly succeeded.")
+            XCTFail("Decoding unexpectedly succeeded.")
         } catch let error as ParserError {
             // Then
             let expectedPrefix = "Parser Deserialization Error - JSON data deserialization failed with error:" // prefix
@@ -293,7 +293,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "key_does_not_exist")
 
-            XCTFail("Parser unexpectedly succeeded.")
+            XCTFail("Decoding unexpectedly succeeded.")
         } catch let error as ParserError {
             // Then
             let actualValue = error.description
@@ -312,7 +312,7 @@ class DecodableTestCase: BaseTestCase {
             // When
             let _: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "testDictionary")
 
-            XCTFail("Parser unexpectedly succeeded.")
+            XCTFail("Decoding unexpectedly succeeded.")
         } catch let error as ParserError {
             // Then
             let actualValue = error.description
@@ -365,7 +365,7 @@ class DecodableTestCase: BaseTestCase {
             // Given, When
             let _ = try type.init(json: value)
 
-            XCTFail("Parser unexpectedly succeeded")
+            XCTFail("Decodable initializer unexpectedly succeeded")
         } catch let error as ParserError {
             // Then
             let actualValue = error.failureReason

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -30,11 +30,11 @@ class DecodableTestCase: BaseTestCase {
 
     // MARK: - Decodable API Success Tests
 
-    func testThatParseOnADecodableSucceeds() {
         // Given
         let data = loadJSONDataForFileNamed("PropertyTypesTest")
 
         // When
+    func testThatDecodeOnADecodableSucceeds() {
         do {
             let testObject: TestObject = try Elevate.decodeObject(from: data, atKeyPath: "sub-object")
 
@@ -47,11 +47,11 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    func testThatParseOnAnArraySucceeds() {
         // Given
         let data = loadJSONDataForFileNamed("ArrayTest")
 
         // When
+    func testThatDecodeOnAnArraySucceeds() {
         do {
             let result: [TestObject] = try Elevate.decodeArray(from: data, atKeyPath: "items")
 
@@ -157,7 +157,7 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
-    // MARK: - Decoable Primitive Failure Tests
+    // MARK: - Decodable Primitive Failure Tests
 
     func testThatParseObjectThrowsForInvalidString() {
         // Given
@@ -353,7 +353,7 @@ class DecodableTestCase: BaseTestCase {
         decodableErrorTest(Bool.self, value: "1")
     }
 
-    // MARK: Private Helper Methods
+    // MARK: - Private - Helper Methods
 
     private func decodableErrorTest(type: Decodable.Type, value: Any) {
         do {

--- a/Tests/DecodableTests.swift
+++ b/Tests/DecodableTests.swift
@@ -157,6 +157,22 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
+    func testThatDecodeObjectDecodesDictionarySuccessfully() {
+        do {
+            // Given
+            let data = "{ \"key\" : \"value\" }".data(using: .utf8)!
+
+            // When
+            let result: [String: String] = try Elevate.decodeObject(from: data, atKeyPath: "")
+
+            // Then
+            XCTAssertEqual(result.count, 1)
+            XCTAssertEqual(result["key"], "value")
+        } catch {
+            XCTFail("Test unexpectedly failed with error: \(error)")
+        }
+    }
+
     // MARK: - Decodable Primitive Failure Tests
 
     func testThatStringDecodableInitializerThrowsForInvalidString() {
@@ -261,6 +277,23 @@ class DecodableTestCase: BaseTestCase {
         }
     }
 
+    func testThatDictionaryDecodableInitializerThrowsForInvalidDictionary() {
+        do {
+            // Given
+            let json: Any = "value"
+
+            // When
+            let _ = try Dictionary<String, String>(json: json)
+
+            XCTFail("Dictionary initializer unexpectedly succeeded in parsing data of incorrect type")
+        } catch let error as ParserError {
+            // Then
+            XCTAssertEqual(error.failureReason, "JSON object was not of type: Dictionary<String, String>")
+        } catch {
+            XCTFail("Incorrect error type was thrown while parsing Decodable")
+        }
+    }
+
     // MARK: - Decodable Failure Tests
 
     func testThatDecodeObjectThrowsWithInvalidJSON() {
@@ -356,6 +389,7 @@ class DecodableTestCase: BaseTestCase {
         decodableErrorTest(type: Float.self, value: "1")
         decodableErrorTest(type: Double.self, value: "1")
         decodableErrorTest(type: Bool.self, value: "1")
+        decodableErrorTest(type: [String: String].self, value: "1")
     }
 
     // MARK: - Private - Helper Methods

--- a/Tests/ParserTests.swift
+++ b/Tests/ParserTests.swift
@@ -168,7 +168,7 @@ class ParserTestCase: BaseTestCase {
 
     func testThatItGeneratesADeserializationErrorForInvalidData() {
         // Given
-        let data: Data! = "not json data".data(using: String.Encoding.utf8)
+        let data: Data! = "not json data".data(using: .utf8)
 
         // When
         do {
@@ -696,7 +696,7 @@ class ParserJSONFragmentDataTestCase: BaseTestCase {
             let boolData = Data(bytes: &boolValue, count: MemoryLayout<Bool>.size)
             values.append(boolData as Data)
 
-            let stringData = "Some random string".data(using: String.Encoding.utf8, allowLossyConversion: false)!
+            let stringData = "Some random string".data(using: .utf8, allowLossyConversion: false)!
             values.append(stringData)
 
             return values

--- a/Tests/ParserTests.swift
+++ b/Tests/ParserTests.swift
@@ -43,7 +43,7 @@ class ParserTestCase: BaseTestCase {
                 schema.addProperty(keyPath: "testFloat", type: .float)
                 schema.addProperty(keyPath: "testDouble", type: .double)
                 schema.addProperty(keyPath: "testNull", type: .string, optional: true)
-                schema.addProperty(keyPath: "testDictionary", type: .dictionary)
+                schema.addProperty(keyPath: "testDictionary", type: .dictionary, decodableType: [String: String].self)
                 schema.addProperty(keyPath: "testDate", type: .string, decoder: dateDecoder)
                 schema.addProperty(keyPath: "testURL", type: .url)
                 schema.addProperty(keyPath: "sub-object", type: .dictionary, decoder: ValidDecoder())
@@ -59,9 +59,9 @@ class ParserTestCase: BaseTestCase {
             XCTAssertEqual(entity["testDouble"] as? Double, 1.1111, "Parsed Double did not equal value from json file.")
             XCTAssertTrue(entity["testNull"] == nil, "Parsed value did not equal nil from json file.")
 
-            let jsonDictionary = entity["testDictionary"] as! [String: Any]
+            let jsonDictionary = entity["testDictionary"] as? [String: Any]
 
-            XCTAssertEqual(jsonDictionary["key1"] as? String, "value1", "Parsed Dictionary<String, Any> did not equal value from json file.")
+            XCTAssertEqual(jsonDictionary?["key1"] as? String, "value1", "Parsed Dictionary<String, Any> did not equal value from json file.")
             XCTAssertTrue(entity["sub-object"] is TestObject, "Parsed sub object did not contain value of correct type")
 
             if let subObject = entity["sub-object"] as? TestObject {


### PR DESCRIPTION
This PR adds the ability to decode Dictionaries directly with the top-level `decodeObject` API *AND* validate the Dictionary `Key` and `Value` types. This was only partially implemented before in the `decodeObject` implementation.

What this allows you to do now is:

```swift
let result: [String: String] = try Elevate.decodeObject(from: data, atKeyPath: "")

// or

let entity = try Parser.parseEntity(json: json) { schema in
    schema.addProperty(keyPath: "", type: .dictionary, decodableType: [String: String].self)
}
```

The first example didn't used to work because `Dictionary` itself did not conform to `Decodable`. The second example used to work as long as you didn't specify the `decodableType`. That was unfortunate though when you need to actually validate that not only is the JSON object a `Dictionary`, but is a `Dictionary` of a given type.

Now you can do both with these changes. I've also added tests for all these cases and cleaned up a bunch of things throughout the test suite.

There's also one other major change to the `Decodable` implementations where I removed the bridging to `NSNumber` before going back to the Swift type. This should definitely improve performance for the primitive type decoding.