### PR TITLE
Set DictionaryExtractionPrecedence to be higher than ??

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 #### 2.x Releases
 
-* `2.2.x` Releases = [2.2.0](#220)
+* `2.2.x` Releases = [2.2.0](#220) | [2.2.1](#221)
 * `2.1.x` Releases = [2.1.0](#210)
 * `2.0.x` Releases = [2.0.0](#200)
 
@@ -15,6 +15,17 @@ All notable changes to this project will be documented in this file.
 * `1.0.x` Releases - [1.0.0](#100)
 
 ---
+
+## [2.2.1](https://github.com/Nike-Inc/Elevate/releases/tag/2.2.1)
+
+Released on 2017-02-09. All issues associated with this milestone can be found using this
+[filter](https://github.com/Nike-Inc/Elevate/milestone/4?closed=1).
+
+#### Updated
+
+- Changed `DictionaryExtractionPrecedence` to have a precedence higher than `NilCoalescingPrecedence` 
+  - Added by [Dave Camp](https://github.com/atomiccat) in Pull Request
+  [#27](https://github.com/Nike-Inc/Elevate/pull/27).
 
 ## [2.2.0](https://github.com/Nike-Inc/Elevate/releases/tag/2.2.0)
 

--- a/Source/SchemaPropertyExtraction.swift
+++ b/Source/SchemaPropertyExtraction.swift
@@ -26,7 +26,7 @@ import Foundation
 
 precedencegroup DictionaryExtractionPrecedence {
     associativity: left
-    higherThan: AssignmentPrecedence
+    higherThan: NilCoalescingPrecedence
 }
 
 infix operator <-! : DictionaryExtractionPrecedence

--- a/Tests/PropertyExtractionTests.swift
+++ b/Tests/PropertyExtractionTests.swift
@@ -135,15 +135,15 @@ class PropertyExtractionTestCase: BaseTestCase {
         XCTAssertEqual(anyArray, ["value_0", "value_1"])
     }
 
-    func testOptionalArrayForKeyPathOperator() {
+    func testExtractionPrecedence() {
         // Given, When
-        let stringsArray: [String]? = properties <--? "array"
-        let anyArray: [String]? = properties <--? "array_of_any_values"
-        let missingKey: [String]? = properties <--? "key_does_not_exist"
+        let string: String = properties <-? "nope" ?? "default string"
+        let stringsArray: [String] = properties <--? "nope" ?? ["default", "value"]
 
         // Then
-        XCTAssertEqual(stringsArray ?? [], ["value_0", "value_1"])
-        XCTAssertEqual(anyArray ?? [], ["value_0", "value_1"])
-        XCTAssertNil(missingKey)
+        XCTAssertEqual(string, "default string")
+        XCTAssertEqual(stringsArray.count, 2)
+        XCTAssertEqual(stringsArray[0], "default")
+        XCTAssertEqual(stringsArray[1], "value")
     }
 }

--- a/Tests/PropertyExtractionTests.swift
+++ b/Tests/PropertyExtractionTests.swift
@@ -135,6 +135,18 @@ class PropertyExtractionTestCase: BaseTestCase {
         XCTAssertEqual(anyArray, ["value_0", "value_1"])
     }
 
+    func testOptionalArrayForKeyPathOperator() {
+        // Given, When
+        let stringsArray: [String]? = properties <--? "array"
+        let anyArray: [String]? = properties <--? "array_of_any_values"
+        let missingKey: [String]? = properties <--? "key_does_not_exist"
+
+        // Then
+        XCTAssertEqual(stringsArray ?? [], ["value_0", "value_1"])
+        XCTAssertEqual(anyArray ?? [], ["value_0", "value_1"])
+        XCTAssertNil(missingKey)
+    }
+
     func testExtractionPrecedence() {
         // Given, When
         let string: String = properties <-? "nope" ?? "default string"


### PR DESCRIPTION
Allows for `entity["key"] ?? <default>` syntax.